### PR TITLE
트랜잭션 update, select쿼리 문제 해결

### DIFF
--- a/Api-gateway/src/main/resources/application.yml
+++ b/Api-gateway/src/main/resources/application.yml
@@ -2,10 +2,10 @@ spring:
   application:
     name: apigw
   profiles:
-    active: dev
+    active: local
   config:
-    import: optional:configserver:http://darakbang-config-service-1:8071
-      #optional:configserver:http://localhost:8071
+    import: #optional:configserver:http://darakbang-config-service-1:8071
+      optional:configserver:http://localhost:8071
 
 management:
   endpoints:

--- a/Member/src/main/java/org/example/controller/MemberController.java
+++ b/Member/src/main/java/org/example/controller/MemberController.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 public class MemberController {
     private final MemberService memberService;
     private final PaymentsService paymentsService;
+
     @Operation(
             operationId = "signup",
             description = "아이디,비밀번호,이름등을 입력받아 회원가입",
@@ -64,12 +65,19 @@ public class MemberController {
     public MemberDto Profile(@PathVariable(value = "nick_name",required = false) @Parameter(name = "닉네임 입력") String nickName, @PathVariable("email")String email){
         return memberService.profile(nickName);
     }
+
     @GetMapping("/nick_name")
     public String getNickName(@RequestParam("email") String email){return memberService.getNickName(email);}
+
 
     @GetMapping("/user_info")
     public String getEmail(@RequestParam("email") String email){return memberService.profileImg(email);}
 
+    @Operation(
+            operationId = "profile",
+            description = "프로필 수정 요청",
+            summary = "프로필 업데이트"
+    )
     @PutMapping(path = "/profile/{email}",consumes = {MediaType.APPLICATION_JSON_VALUE , MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<ResponseCustom> changeProfile(@RequestPart(name = "req",required = false) @Parameter MemberDto memberDto,
                                                         @RequestPart(name = "img",required = false) @Parameter MultipartFile img,
@@ -77,9 +85,13 @@ public class MemberController {
         return ResponseEntity.ok(memberService.updateProfile(img,memberDto,email));
     }
 
-
+    @Operation(
+            operationId = "payments",
+            description = "결제 요청",
+            summary = "결제"
+    )
     @PostMapping("/payments/{email}")
-    public ResponseEntity<PaymentsRes> payments(@RequestBody PurchaseDto purchaseDto,@PathVariable("email") String email) {
+    public ResponseEntity<PaymentsRes> payments(@RequestBody @Parameter(name = "total_point, payments_list") PurchaseDto purchaseDto,@PathVariable("email") String email) {
         return ResponseEntity.ok(paymentsService.purchase(purchaseDto,email));
     }
 

--- a/Member/src/main/java/org/example/dto/PurchaseDto.java
+++ b/Member/src/main/java/org/example/dto/PurchaseDto.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 @Data
 @RequiredArgsConstructor
-
 public class PurchaseDto {
     private String email;
     private int total_point;

--- a/Member/src/main/java/org/example/repository/member/MemberRepositoryImpl.java
+++ b/Member/src/main/java/org/example/repository/member/MemberRepositoryImpl.java
@@ -1,8 +1,10 @@
 package org.example.repository.member;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import lombok.extern.slf4j.Slf4j;
 import org.example.entity.Member;
 import org.example.entity.QMember;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,6 +65,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     }
 
     @Override
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     public void updatePoint(int point,String email) {
         QMember qMember = QMember.member;
          query.update(qMember).set(qMember.point,point).where(qMember.email.eq(email)).execute();

--- a/Member/src/main/java/org/example/service/PaymentsService.java
+++ b/Member/src/main/java/org/example/service/PaymentsService.java
@@ -1,7 +1,7 @@
 package org.example.service;
 
 
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.dto.PaymentsReq;
@@ -12,6 +12,8 @@ import org.example.repository.member.MemberRepository;
 import org.example.service.purchase.ProductFeign;
 import org.example.service.purchase.PurchaseFeign;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.HashMap;
 import java.util.Optional;
 
 @Service
@@ -23,61 +25,58 @@ public class PaymentsService {
     private final ProductFeign productFeign;
     private final PurchaseFeign purchaseFeign;
 
+    private final HashMap<String,Integer> sellers = new HashMap<>();
+
     @Transactional
     public PaymentsRes purchase(PurchaseDto purchaseDto, String email){
         Optional<Member> consumer = memberRepository.findByEmail(email);
         if (consumer.isEmpty()){return PaymentsRes.builder().charge(null).message("등록되지 않은 이메일입니다").build();}
-        int consumerPoint=consumer.get().getPoint()- purchaseDto.getTotal_point();
+
+        int consumerPoint=consumer.get().getPoint() - purchaseDto.getTotal_point();
+        log.info(String.valueOf(consumerPoint));
+
         if (purchaseDto.getTotal_point()>consumer.get().getPoint()){return PaymentsRes.builder().charge(true).point(Math.abs(consumerPoint)).message("포인트 충전 필요").build();}
         else {
             memberRepository.updatePoint(consumerPoint,email);
             for (PaymentsReq req : purchaseDto.getPayments_list()){
-                if (req.getSeller().isEmpty()){return PaymentsRes.builder().charge(null).message("회원가입후에 이용가능합니다.").build();}
-                else {
-                    Optional<Member> seller = memberRepository.findByEmail(req.getSeller());
-                    if(seller.isPresent()){
-                        int sellerPoint=seller.get().getPoint()+ req.getProduct_point();
-                        boolean complete = productFeign.changeStateSuccess(req.getProduct_id(),-1);
-                        if (complete){
-                            memberRepository.updatePoint(sellerPoint,seller.get().getEmail());
-                            req.setConsumer(email);
-                        }
-                        else {
-                            return PaymentsRes.builder().charge(false).message("상품이 없습니다").build();
-                        }
-                    }
-                    else {
-                        return PaymentsRes.builder().charge(null).message("판매자가 없는 상품입니다").build();
-                    }
-                }
+                req.setConsumer(purchaseDto.getEmail());
+                if(!purchaseOne(req)){return PaymentsRes.builder().charge(false).message("상품이 없습니다").build();}
+            }
+            for (String sellerEmail : sellers.keySet()){
+                memberRepository.updatePoint(sellers.get(sellerEmail),sellerEmail);
             }
         }
         purchaseFeign.saveOrder(purchaseDto.getPayments_list());
         return PaymentsRes.builder().charge(false).message("구매 성공").build();
     }
+
     @Transactional
     public PaymentsRes purchaseSuccess(PurchaseDto purchaseDto){
         Optional<Member> consumer = memberRepository.findByEmail(purchaseDto.getEmail());
         if (consumer.isEmpty()){return PaymentsRes.builder().charge(null).message("등록되지 않은 이메일입니다").build();}
         memberRepository.updatePoint(0,purchaseDto.getEmail());
         for (PaymentsReq req : purchaseDto.getPayments_list()){
-            if (req.getSeller().isEmpty()){return PaymentsRes.builder().charge(null).message("등록되지 않은 이메일입니다").build();}
-            else {
-                Optional<Member> seller = memberRepository.findByEmail(req.getSeller());
-                if (seller.isEmpty()){return PaymentsRes.builder().charge(null).message("판매자가 없는 상품입니다.").build();}
-                int sellerPoint=seller.get().getPoint()+ req.getProduct_point();
-                boolean complete = productFeign.changeStateSuccess(req.getProduct_id(),-1);
-                if (complete){
-                    memberRepository.updatePoint(sellerPoint,seller.get().getEmail());
-                    req.setConsumer(purchaseDto.getEmail());
-                }
-                else {
-                    return PaymentsRes.builder().charge(false).message("상품이 없습니다").build();
-                }
-            }
+            req.setConsumer(purchaseDto.getEmail());
+            if(!purchaseOne(req)){return PaymentsRes.builder().charge(false).message("상품이 없습니다").build();}
+        }
+        for (String email : sellers.keySet()){
+            memberRepository.updatePoint(sellers.get(email),email);
         }
         purchaseFeign.saveOrder(purchaseDto.getPayments_list());
         return PaymentsRes.builder().charge(false).message("구매 성공").build();
+    }
+
+    @Transactional
+    public boolean purchaseOne(PaymentsReq req){
+        Optional<Member> seller = memberRepository.findByEmail(req.getSeller());
+            if (seller.isEmpty()){return false;}
+        if (sellers.containsKey(seller.get().getEmail())){
+            int total = sellers.get(seller.get().getEmail())+ req.getProduct_point();
+            log.info(String.valueOf(total));
+            sellers.put(seller.get().getEmail(),total);
+        }
+        else {sellers.put(seller.get().getEmail(),seller.get().getPoint()+ req.getProduct_point());}
+        return productFeign.changeStateSuccess(req.getProduct_id(),-1);
     }
 
 }

--- a/Member/src/main/java/org/example/service/purchase/ProductFeign.java
+++ b/Member/src/main/java/org/example/service/purchase/ProductFeign.java
@@ -4,8 +4,8 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-//@FeignClient(name = "ProductApi",url = "http://localhost:7080/product")
-@FeignClient(name = "ProductApi",url = "http://darakbang-product-service-1:7080/product")
+@FeignClient(name = "ProductApi",url = "http://localhost:7080/product")
+//@FeignClient(name = "ProductApi",url = "http://darakbang-product-service-1:7080/product")
 public interface ProductFeign {
     @PostMapping("/payments/sell")
     public boolean changeStateSuccess(@RequestParam("product_id")Long product_id,@RequestParam("state") int state);

--- a/Member/src/main/java/org/example/service/purchase/PurchaseFeign.java
+++ b/Member/src/main/java/org/example/service/purchase/PurchaseFeign.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
-//@FeignClient(name = "PurchaseApi",url = "http://localhost:6080/payments")
-@FeignClient(name = "PurchaseApi",url = "http://darakbang-purchase-service-1:7080/product")
+@FeignClient(name = "PurchaseApi",url = "http://localhost:6080/payments")
+//@FeignClient(name = "PurchaseApi",url = "http://darakbang-purchase-service-1:6080/payments")
 public interface PurchaseFeign {
     @PostMapping("/complete")
     public void saveOrder(@RequestBody List<PaymentsReq> paymentsReq);

--- a/Member/src/main/resources/application.yml
+++ b/Member/src/main/resources/application.yml
@@ -2,10 +2,10 @@ spring:
   application:
     name: member
   profiles:
-    active: dev
+    active: local
   config:
-    import: optional:configserver:http://darakbang-config-service-1:8071
-      #optional:configserver:http://localhost:8071
+    import: #optional:configserver:http://darakbang-config-service-1:8071
+      optional:configserver:http://localhost:8071
 
 management:
   endpoints:

--- a/Product/src/main/java/org/example/controller/ProductController.java
+++ b/Product/src/main/java/org/example/controller/ProductController.java
@@ -98,16 +98,31 @@ public class ProductController {
     public ResponseEntity<ProductDetailRes> getProduct(@RequestParam("product_id") Long productId) {
         return productService.findProductDetail(productId);
     }
-
+    @Operation(
+            operationId = "like",
+            description = "좋아요 상품 등록 요청",
+            summary = "좋아요"
+    )
     @PostMapping("/like/{product_id}/{email}")
     public ResponseEntity<SuccessRes> uploadLike(@PathVariable("product_id") Long productId, @PathVariable("email") String email){
         return ResponseEntity.ok(wishListService.likeRegistration(email, productId));
     }
 
+    @Operation(
+            operationId = "like",
+            description = "좋아요 상품 조회 요청",
+            summary = "좋아요"
+    )
     @GetMapping("/like/{email}")
     public ResponseEntity<WishListDto> getLikeProduct(@PathVariable("email") String email){
         return ResponseEntity.ok(wishListService.showLikeProduct(email));
     }
+
+    @Operation(
+            operationId = "like",
+            description = "좋아요 상품 삭제 요청",
+            summary = "좋아요"
+    )
     @DeleteMapping("/like/{product_id}/{email}")
     public ResponseEntity<SuccessRes> deleteLikeProduct( @PathVariable("product_id") Long productId, @PathVariable("email") String email){
         return ResponseEntity.ok(wishListService.delLikeProduct(email,productId));

--- a/Product/src/main/java/org/example/repository/ProductRepository.java
+++ b/Product/src/main/java/org/example/repository/ProductRepository.java
@@ -27,7 +27,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "p.categoryId = :categoryid, " +
             "p.expireAt = :expireat " +
             "where p.productId = :productid")
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    //@Lock(LockModeType.PESSIMISTIC_WRITE)
     void updateProduct(@Param("productid") Long productid,
                        @Param("productname") String productName,
                        @Param("price") int price,
@@ -38,16 +38,16 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     Page<Product> findAll(Pageable pageable) ;
 
-    @Lock(LockModeType.PESSIMISTIC_READ)
+    //@Lock(LockModeType.PESSIMISTIC_READ)
     @Query("SELECT p FROM Product p WHERE p.productName Like %:keyword% and p.productId != :product_id")
     List<Product> findByProductNameKeyword(@Param("keyword") String keyword,@Param("product_id") Long productId);
     //제목과 유사한 키워드에 따라서 검색하는 쿼리입니다.
 
-    @Lock(LockModeType.PESSIMISTIC_READ)
+    //@Lock(LockModeType.PESSIMISTIC_READ)
     @Query("SELECT p FROM Product p WHERE p.categoryId = :category_id and p.productId != :product_id")
     List<Product> findByProductCategory(@Param("category_id") int categoryId,@Param("product_id") Long productId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    //@Lock(LockModeType.PESSIMISTIC_WRITE)
     @Modifying
     @Query("UPDATE Product p SET p.state = :state WHERE p.productId = :productid")
     void updateState(@Param("state") int state, @Param("productid") Long productId) ;

--- a/Product/src/main/java/org/example/service/ProductService.java
+++ b/Product/src/main/java/org/example/service/ProductService.java
@@ -52,7 +52,7 @@ public class ProductService {
         return ResponseEntity.ok(new SuccessRes(product.getProductName(),"success"));
     }
 
-
+    @Transactional
     public ResponseEntity<Page<ProductDto>> findProductPage (int page){
         Pageable pageable = PageRequest.of(page, 9, Sort.by(Sort.Direction.ASC, "productId"));
         Page<Product> productPage = productRepository.findAll(pageable);
@@ -60,6 +60,7 @@ public class ProductService {
         return ResponseEntity.ok(products);
     }
 
+    @Transactional
     public ResponseEntity<SuccessRes> deleteProduct(Long productId, String email) throws IOException {
         Optional<Product> product = productRepository.findByProductId(productId);
         if (product.isPresent()){
@@ -76,7 +77,7 @@ public class ProductService {
         }
     }
 
-
+    @Transactional
     public ResponseEntity<ProductDetailRes> findProductDetail(Long productId)
     {
         Optional<Product> selectedProduct = productRepository.findByProductId(productId);

--- a/Product/src/main/java/org/example/service/member/MemberFeign.java
+++ b/Product/src/main/java/org/example/service/member/MemberFeign.java
@@ -6,8 +6,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Component
-//@FeignClient(name = "member",url = "http://localhost:8080/member")
-@FeignClient(name = "member",url = "http://darakbang-member-service-1:8080/member")
+@FeignClient(name = "member",url = "http://localhost:8080/member")
+//@FeignClient(name = "member",url = "http://darakbang-member-service-1:8080/member")
 public interface MemberFeign {
     @GetMapping("/nick_name")
     public String getNickName(@RequestParam("email") String email);

--- a/Product/src/main/resources/application.yml
+++ b/Product/src/main/resources/application.yml
@@ -2,10 +2,10 @@ spring:
   application:
     name: product
   profiles:
-    active: dev
+    active: local
   config:
-    import: optional:configserver:http://darakbang-config-service-1:8071
-      #optional:configserver:http://localhost:8071
+    import: #optional:configserver:http://darakbang-config-service-1:8071
+      optional:configserver:http://localhost:8071
 
 management:
   endpoints:

--- a/Purchase/src/main/resources/application.yml
+++ b/Purchase/src/main/resources/application.yml
@@ -2,10 +2,10 @@ spring:
   application:
     name: purchase
   profiles:
-    active: dev
+    active: local
   config:
-    import: optional:configserver:http://darakbang-config-service-1:8071
-      #optional:configserver:http://localhost:8071
+    import: #optional:configserver:http://darakbang-config-service-1:8071
+      optional:configserver:http://localhost:8071
 
 management:
   endpoints:


### PR DESCRIPTION
결제 서비스에서 사용자의 포인트 update 쿼리문이 커밋되지 않은 상태에서 같은 사용자의 포인트를 조회했을 때 같은 데이터를 가져와서 트랜잭션이 종료되고 커밋되었을 때 update 쿼리의 결과가 기댓값과 일치하지 않는 문제점을 어플리케이션 수준에서 같은 사용자의 포인트를 조회하려고 하는것을 저장해둔 객체의 포인트로 사용하는 로직으로 변경